### PR TITLE
feat(dev): add option for adding styles to global object instead of <head> element (for using in Shadow DOM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,34 @@ As the entry file of the remote module, not required, default is `remoteEntry.js
 ```js
 exposes: {
 // 'externally exposed component name': 'externally exposed component address'
-    './remote-simple-button': './src/components/Button.vue',
-        './remote-simple-section': './src/components/Section.vue'
+    './remote-simple-button': './src/components/Button.vue', 
+    './remote-simple-section': './src/components/Section.vue'
 },
+```
+
+* If you need a more complex configuration
+```js
+exposes: {
+    './remote-simple-button': {
+        import: './src/components/Button.vue',
+        name: 'customChunkName',
+        dontAppendStylesToHead: true
+    },
+},
+```
+The `import` property is the address of the module. If you need to specify a custom chunk name for the module use the `name` property.
+
+The `dontAppendStylesToHead` property is used if you don't want the plugin to automatically append all styles of the exposed component to the `<head>` element, which is the default behavior. It's useful if your component uses a ShadowDOM and the global styles wouldn't affect it anyway. The plugin will then expose the addresses of the CSS files in the global `window` object, so that your exposed component can append the styles inside the ShadowDOM itself. The key under the `window` object used for styles will be `css__{name_of_the_app}__{key_of_the_exposed_component}`. In the above example it would be `css__App__./remote-simple-button`, assuming that the global `name` option (not the one under exposed component configuration) is `App`. The value under this key is an array of strings, which contains the addresses of CSS files. In your exposed component you can iterate over this array and manually create `<link>` elements with `href` attribute set to the elements of the array like this:
+```js
+const styleContainer = document.createElement("div");
+const hrefs = window["css__App__./remote-simple-button"];
+
+hrefs.forEach((href: string) => {
+    const link = document.createElement('link')
+    link.href = href
+    link.rel = 'stylesheet'
+    styleContainer.appendChild(link);
+});
 ```
 
 ----

--- a/packages/lib/__tests__/utils.spec.ts
+++ b/packages/lib/__tests__/utils.spec.ts
@@ -43,11 +43,13 @@ test('get moduleMarker', () => {
 test('parse exposes options', () => {
   const normalizeSimple = (item) => ({
     import: item,
-    name: undefined
+    name: undefined,
+    dontAppendStylesToHead: false
   })
   const normalizeOptions = (item) => ({
     import: item.import,
-    name: item.name || undefined
+    name: item.name || undefined,
+    dontAppendStylesToHead: item.dontAppendStylesToHead || false
   })
   // string[]
   let exposes: (string | ExposesObject)[] | ExposesObject = [
@@ -81,7 +83,8 @@ test('parse exposes options', () => {
   exposes = {
     './Content': {
       import: './src/components/Content.vue',
-      name: 'content'
+      name: 'content',
+      dontAppendStylesToHead: true
     },
     './Button': {
       import: './src/components/Button.js',
@@ -91,11 +94,19 @@ test('parse exposes options', () => {
   ret = parseOptions(exposes, normalizeSimple, normalizeOptions)
   expect(ret[0]).toMatchObject([
     './Content',
-    { import: './src/components/Content.vue', name: 'content' }
+    {
+      import: './src/components/Content.vue',
+      name: 'content',
+      dontAppendStylesToHead: true
+    }
   ])
   expect(ret[1]).toMatchObject([
     './Button',
-    { import: './src/components/Button.js', name: 'button' }
+    {
+      import: './src/components/Button.js',
+      name: 'button',
+      dontAppendStylesToHead: false
+    }
   ])
   // console.log(JSON.stringify(ret))
 

--- a/packages/lib/src/utils/index.ts
+++ b/packages/lib/src/utils/index.ts
@@ -84,12 +84,14 @@ export function parseExposeOptions(
     (item) => {
       return {
         import: item,
-        name: undefined
+        name: undefined,
+        dontAppendStylesToHead: false
       }
     },
     (item) => ({
       import: item.import,
-      name: item.name || undefined
+      name: item.name || undefined,
+      dontAppendStylesToHead: item.dontAppendStylesToHead || false
     })
   )
 }

--- a/packages/lib/types/index.d.ts
+++ b/packages/lib/types/index.d.ts
@@ -121,6 +121,13 @@ declare interface ExposesConfig {
    * Custom chunk name for the exposed module.
    */
   name?: string
+
+  /**
+   * If false, the link element with styles is put in <head> element. If true, the href argument of all links objects
+   * are put under global window object and can be retrieved by the component. It's for using with ShadowDOM, when
+   * the component must place the styles inside the ShadowDOM instead of the <head> element.
+   */
+  dontAppendStylesToHead?: boolean
 }
 
 /**


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
All styles for exposed components are always put in the <head> element. This is fine unless a component creates a Shadow DOM, because then the styles inside the <head> won't affect the contents of the Shadow DOM. That's why I added a configuration option to the plugin. When the new boolean is set to 'true', then the <link> element is created and instead being put in the <head> element, it's held in memory and put under the global 'window' object. From this point the exposed component that creates a Shadow DOM can take this <link> element and put it directly inside the Shadow DOM.

This PR fixes the following issue: https://github.com/originjs/vite-plugin-federation/issues/488

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other